### PR TITLE
Fix scoreboard color correction not disabling exclusivity

### DIFF
--- a/vscripts/client/cl_scoreboard.nut
+++ b/vscripts/client/cl_scoreboard.nut
@@ -897,6 +897,7 @@ function HideScoreboard()
 	UpdateMainHudVisibility( localPlayer, 0.0 )
 	ShowScriptHUD( localPlayer )
 	ClearCrosshairPriority( crosshairPriorityLevel.MENU )
+	ColorCorrection_SetExclusive( file.menuColorCorrection, false )
 	ColorCorrection_SetWeight( file.menuColorCorrection, 0.0 )
 }
 


### PR DESCRIPTION
Fixes the scoreboard color correction not disabling its exclusivity, and messing with other color corrections that use `ColorCorrection_SetExclusive`. To be honest, idk if this even affects anything in the base game but it wouldn't hurt to have it

In the showcases below i modified the fullscreen map to use a color correction effect

Before:

https://github.com/user-attachments/assets/01cb9c0d-7b28-4812-a3a5-735b6fd10554

After:

https://github.com/user-attachments/assets/2f6803b8-1c1f-469c-803a-a7229071c97e


