### PR TITLE
Fix Titan EMP overlay not covering the entire screen

### DIFF
--- a/vscripts/client/cl_titan_cockpit.nut
+++ b/vscripts/client/cl_titan_cockpit.nut
@@ -1132,11 +1132,13 @@ function TitanEMP_Internal( maxValue, duration, fadeTime, doFlash = true, doSoun
 	local wide = 16
 	local tall = 9
 
+	local fovOffset = Graph( GetConVarFloat( "cl_fovScale" ), 1.0, 1.7, 4, 2.5 )
+
 	local empVgui = CreateClientsideVGuiScreen( "vgui_titan_emp", VGUI_SCREEN_PASS_VIEWMODEL, Vector(0,0,0), Vector(0,0,0), wide, tall );
 
 	//empVgui.SetParent( player.GetViewModelEntity(), "CAMERA_BASE" )
 	empVgui.SetParent( player )
-	empVgui.SetAttachOffsetOrigin( Vector( 4, wide / 2, -tall / 2 ) )
+	empVgui.SetAttachOffsetOrigin( Vector( fovOffset, wide / 2, -tall / 2 ) )
 	empVgui.SetAttachOffsetAngles( angles )
 
 	empVgui.GetPanel().WarpEnable()

--- a/vscripts/client/levels/cl_mp_o2.nut
+++ b/vscripts/client/levels/cl_mp_o2.nut
@@ -2795,10 +2795,11 @@ function NukeScreenFlashFX()
 		local angles = Vector( 0, -90, 90 )
 		local wide = 16
 		local tall = 9
+		local fovOffset = Graph( GetConVarFloat( "cl_fovScale" ), 1.0, 1.7, 4, 2.5 )
 		local empVgui = CreateClientsideVGuiScreen( "vgui_titan_emp", VGUI_SCREEN_PASS_VIEWMODEL, Vector(0,0,0), Vector(0,0,0), wide, tall );
 
 		empVgui.SetParent( player )
-		empVgui.SetAttachOffsetOrigin( Vector( 4, wide / 2, -tall / 2 ) )
+		empVgui.SetAttachOffsetOrigin( Vector( fovOffset, wide / 2, -tall / 2 ) )
 		empVgui.SetAttachOffsetAngles( angles )
 		empVgui.GetPanel().WarpEnable()
 


### PR DESCRIPTION
It's only noticeable on higher FOVs. Fix [backported from TF2](https://github.com/Syampuuh/Titanfall2/blob/master/scripts/vscripts/client/cl_titan_cockpit.nut#L1523)

To test this, hop in a titan and try doing anything that triggers the EMP overlay (arc weapons, export trap, boneyard campaign)